### PR TITLE
Bugfix: Debugger error indicator badge misaligned (#2569)

### DIFF
--- a/frontend/src/_styles/left-sidebar.scss
+++ b/frontend/src/_styles/left-sidebar.scss
@@ -86,8 +86,8 @@
   }
   .debugger-badge {
     position: fixed;
-    margin-top: -0.82rem;
-    margin-left: -0.3rem;
+    margin-top: -0.5rem;
+    margin-left: 1.5rem;
     height: 20px;
     width: 20px;
     font-weight: 400;


### PR DESCRIPTION
resolves #2569


![fix image](https://user-images.githubusercontent.com/88718449/161193298-9b8ad5a9-fd92-4fae-8aa3-c39d108e7bb4.PNG)

